### PR TITLE
Show search results when no exact match

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -69,13 +69,75 @@ And you're good to get glossing! Open up Slack and type `/gloss help` to start.
 
 Here's what to do if you've got an older version of Gloss Bot on Heroku and want to upgrade to the latest version. First, guarantee that you've got a backup of your database by following the instructions in [Heroku's PGBackups documentation](https://devcenter.heroku.com/articles/heroku-postgres-backups).
 
-Now, do a `git pull` in your local glossbot directory:
+##### If you used the Deploy To Heroku button
+
+If you intalled Gloss Bot using the *Deploy to Heroku* button, follow the steps below. If not, [skip ahead](#if-you-did-not-use-the-deploy-to-heroku-button).
+
+First, make sure you've got the basics set up by following [Heroku's instructions for getting started with Python](https://devcenter.heroku.com/articles/getting-started-with-python-o).
+
+Open the terminal and clone the Gloss Bot repository onto your machine:
+
+```
+git clone git@github.com:codeforamerica/glossary-bot.git
+```
+
+Then change into the resulting directory:
+
+```
+cd glossary-bot
+```
+
+Find the name of the heroku app that's running Gloss Bot by typing:
+
+```
+heroku apps
+```
+
+This'll show you a list of apps, one of which should be your Gloss Bot instance.
+
+If you're not sure which app is the Gloss Bot app, go to [your Slack's custom integrations page](https://my.slack.com/apps/manage/custom-integrations), click into *Slash Commands*, and find the slash command you configured for Gloss Bot. It'll say something like _When a user enters /gloss, POST to https://my-cool-bot-12345.herokuapp.com/_. Whatever's in the URL in place of 'my-cool-bot-12345' is the name of your app.
+
+Back in the terminal, get more info on the app by typing (replacing _my-cool-bot-12345_ with the name of your app):
+
+```
+heroku info --app my-cool-bot-12345
+```
+
+You'll see a list of information about the app, including its `Git URL`. Copy the URL and use it in this command:
+
+```
+git remote add heroku https://git.heroku.com/my-cool-bot-12345.git
+```
+
+With that command, you've connected your local copy of the Gloss Bot repository to your app on Heroku! You can verify the change like this:
+
+```
+git remote -v
+```
+
+Now, push the latest code to your app on Heroku:
+
+```
+git push -f heroku master
+```
+
+And upgrade the database:
+
+```
+heroku run python manage.py db upgrade --app my-cool-bot-12345
+```
+
+And your Gloss Bot has been updated!
+
+##### If you did not use the Deploy To Heroku button
+
+Change into your local Gloss Bot directory and pull the latest code:
 
 ```
 git pull
 ```
 
-And deploy it to Heroku:
+Deploy it to Heroku:
 
 ```
 git push heroku master

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -78,5 +78,5 @@ python manage.py runtests
 or run an individual test:
 
 ```
-python tests/test_bot.py BotTestCase.test_get_definition
+python tests/test_bot.py TestBot.test_get_definition
 ```

--- a/README.md
+++ b/README.md
@@ -29,3 +29,5 @@ Paste the **Token** from the Slash Command integration into the `SLACK_TOKEN` fi
 When it's done deploying, click the **View** button at the bottom of the form. A **Method Not Allowed** error page will load, but don't worry about that. All you're looking for is your bot's URL, which looks something like `https://my-glossary-bot.herokuapp.com/`. Copy that URL, paste it into the **URL** field of the Slash Command integration page on Slack, and save the integration there.
 
 And now you're good to get glossing! Open up Slack and type `/gloss help` to start.
+
+If you installed Gloss Bot on Heroku using the Deploy on Heroku button and you want to upgrade it with the latest changes, [follow these instructions](DEPLOY.md#if-you-used-the-deploy-to-heroku-button).

--- a/README.md
+++ b/README.md
@@ -30,4 +30,4 @@ When it's done deploying, click the **View** button at the bottom of the form. A
 
 And now you're good to get glossing! Open up Slack and type `/gloss help` to start.
 
-If you installed Gloss Bot on Heroku using the Deploy on Heroku button and you want to upgrade it with the latest changes, [follow these instructions](DEPLOY.md#if-you-used-the-deploy-to-heroku-button).
+If you installed Gloss Bot on Heroku using the Deploy on Heroku button and you want to upgrade it with the latest changes, [follow these instructions](DEPLOY.md#upgrade-on-heroku).

--- a/gloss/models.py
+++ b/gloss/models.py
@@ -1,4 +1,5 @@
 from . import db
+from sqlalchemy.dialects.postgresql import TSVECTOR
 from datetime import datetime
 
 class Definition(db.Model):
@@ -11,6 +12,7 @@ class Definition(db.Model):
     term = db.Column(db.Unicode(), index=True)
     definition = db.Column(db.Unicode())
     user_name = db.Column(db.Unicode())
+    tsv_search = db.Column(TSVECTOR)
 
     def __repr__(self):
         return '<Term: {}, Definition: {}>'.format(self.term, self.definition)

--- a/gloss/views.py
+++ b/gloss/views.py
@@ -239,7 +239,7 @@ def query_definition_and_get_response(slash_command, command_text, user_name, ch
         # remember this query
         log_query(term=command_text, user_name=user_name, action=u'not_found')
 
-        message = u'Sorry, but *Gloss Bot* has no definition for *{term}*. You can set a definition with the command *{command} {term} = _definition_*'.format(command=slash_command, term=command_text)
+        message = u'Sorry, but *Gloss Bot* has no definition for *{term}*. You can set a definition with the command *{command} {term} = <definition>*'.format(command=slash_command, term=command_text)
 
         search_results = get_matches_for_term(command_text)
         if len(search_results):
@@ -406,7 +406,7 @@ def index():
     #
 
     if command_action in HELP_CMDS or command_text == u'' or command_text == u' ':
-        return u'*{command} _term_* to show the definition for a term\n*{command} _term_ = _definition_* to set the definition for a term\n*{command} delete _term_* to delete the definition for a term\n*{command} help* to see this message\n*{command} stats* to show usage statistics\n*{command} learnings* to show recently defined terms\n*{command} search _term_* to search terms and definitions\n*{command} shh _command_* to get a private response\n<https://github.com/codeforamerica/glossary-bot/issues|report bugs and request features>'.format(command=slash_command), 200
+        return u'*{command} <term>* to show the definition for a term\n*{command} <term> = <definition>* to set the definition for a term\n*{command} delete <term>* to delete the definition for a term\n*{command} help* to see this message\n*{command} stats* to show usage statistics\n*{command} learnings* to show recently defined terms\n*{command} search <term>* to search terms and definitions\n*{command} shh <command>* to get a private response\n<https://github.com/codeforamerica/glossary-bot/issues|report bugs and request features>'.format(command=slash_command), 200
 
     #
     # STATS

--- a/gloss/views.py
+++ b/gloss/views.py
@@ -120,7 +120,7 @@ def get_stats():
     # return the message
     return u'\n'.join(lines)
 
-def get_learnings(how_many=12, sort_order=u'recent', offset=0, when=None):
+def get_learnings(how_many=12, sort_order=u'recent', offset=0):
     ''' Gather and return some recent definitions
     '''
     order_descending = Definition.creation_date.desc()
@@ -139,21 +139,8 @@ def get_learnings(how_many=12, sort_order=u'recent', offset=0, when=None):
         prefix_singluar = u'I know the definition for'
         prefix_plural = u'I know definitions for'
 
-    if when == u'today':
-        prefix_singluar = u'Today I learned the definition for'
-        prefix_plural = u'Today I learned definitions for'
-        no_definitions_text = u'I haven\'t learned any definitions today.'
-        definitions = db.session.query(Definition).order_by(order_function).filter(cast(Definition.creation_date, DATE) == date.today()).all()
-
-    elif when == u'yesterday':
-        prefix_singluar = u'Yesterday I learned the definition for'
-        prefix_plural = u'Yesterday I learned definitions for'
-        no_definitions_text = u'I didn\'t learn any definitions yesterday.'
-        date_yesterday = date.today() - timedelta(days=1)
-        definitions = db.session.query(Definition).order_by(order_function).filter(cast(Definition.creation_date, DATE) == date_yesterday).all()
-
     # if how_many is 0, ignore offset and return all results
-    elif how_many == 0:
+    if how_many == 0:
         definitions = db.session.query(Definition).order_by(order_function).all()
     # if order is random and there is an offset, randomize the results after the query
     elif sort_order == u'random' and offset > 0:
@@ -185,9 +172,6 @@ def parse_learnings_params(command_params):
             continue
         if param == u'all':
             recent_args['how_many'] = 0
-            continue
-        if param in (u'today', u'yesterday'):
-            recent_args['when'] = param
             continue
         try:
             passed_int = int(param)

--- a/gloss/views.py
+++ b/gloss/views.py
@@ -244,7 +244,7 @@ def query_definition_and_get_response(slash_command, command_text, user_name, ch
         search_results = get_matches_for_term(command_text)
         if len(search_results):
             search_results_styled = ', '.join([u'*{}*'.format(term) for term in search_results])
-            message = u'{}, or try asking for one of these terms that looks like a near match: {}'.format(message, search_results_styled)
+            message = u'{}, or try asking for one of these terms that may be related: {}'.format(message, search_results_styled)
 
         return message, 200
 

--- a/gloss/views.py
+++ b/gloss/views.py
@@ -269,9 +269,9 @@ def search_term_and_get_response(command_text):
     search_results = get_matches_for_term(command_text)
     if len(search_results):
         search_results_styled = ', '.join([u'*{}*'.format(term) for term in search_results])
-        message = u'*{}* was found in the following terms: {}'.format(command_text, search_results_styled)
+        message = u'Gloss Bot found *{}* in: {}'.format(command_text, search_results_styled)
     else:
-        message = u'*{}* was not found in any terms or definitions.'.format(command_text)
+        message = u'Gloss Bot could not find *{}* in any terms or definitions.'.format(command_text)
 
     return message, 200
 

--- a/migrations/versions/201bae6698f6_added_search.py
+++ b/migrations/versions/201bae6698f6_added_search.py
@@ -1,0 +1,110 @@
+"""Added new column for ranked searching of terms and descriptions
+
+Revision ID: 201bae6698f6
+Revises: 4614666a279f
+Create Date: 2015-10-21 00:31:05.525848
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '201bae6698f6'
+down_revision = '4614666a279f'
+
+from alembic import op
+import sqlalchemy as sa
+
+def upgrade():
+    db_bind = op.get_bind()
+    #
+    # Replace the index for terms with one including varchar_pattern_ops
+    #
+
+    # drop the old index
+    db_bind.execute(sa.sql.text('''
+        DROP INDEX IF EXISTS ix_definitions_term;
+    '''))
+    # create the new index
+    db_bind.execute(sa.sql.text('''
+        CREATE INDEX ix_definitions_term ON definitions (term varchar_pattern_ops);
+    '''))
+
+    #
+    # Support full-text search on terms and descriptions
+    #
+
+    # add the tsv_search column to the definitions table
+    db_bind.execute(sa.sql.text('''
+        ALTER TABLE definitions ADD COLUMN tsv_search tsvector;
+    '''))
+
+    # set up a trigger to populate tsv_search when records are created or altered
+    db_bind.execute(sa.sql.text('''
+        DROP FUNCTION IF EXISTS definitions_search_trigger();
+    '''))
+    db_bind.execute(sa.sql.text('''
+        CREATE FUNCTION definitions_search_trigger() RETURNS trigger AS $$
+        begin
+          new.tsv_search :=
+             setweight(to_tsvector('pg_catalog.english', COALESCE(new.term,'')), 'A') ||
+             setweight(to_tsvector('pg_catalog.english', COALESCE(new.description,'')), 'B');
+          return new;
+        end
+        $$ LANGUAGE plpgsql;
+    '''))
+
+    db_bind.execute(sa.sql.text('''
+        DROP TRIGGER IF EXISTS tsvupdate_definitions_trigger ON definitions;
+    '''))
+    db_bind.execute(sa.sql.text('''
+        CREATE TRIGGER tsvupdate_definitions_trigger BEFORE INSERT OR UPDATE ON definitions FOR EACH ROW EXECUTE PROCEDURE definitions_search_trigger();
+    '''))
+
+    # create an index for tsv_search
+    db_bind.execute(sa.sql.text('''
+        DROP INDEX IF EXISTS ix_definitions_tsv_search;
+    '''))
+    db_bind.execute(sa.sql.text('''
+        CREATE INDEX ix_definitions_tsv_search ON definitions USING gin(tsv_search);
+    '''))
+
+    # populate tsv_search for existing records
+    db_bind.execute(sa.sql.text('''
+        UPDATE definitions SET tsv_search = setweight(to_tsvector('pg_catalog.english', COALESCE(term,'')), 'A') || setweight(to_tsvector('pg_catalog.english', COALESCE(description,'')), 'B');
+    '''))
+
+def downgrade():
+    db_bind = op.get_bind()
+    #
+    # Revert the terms index to the original style
+    #
+
+    # drop the varchar_pattern_ops index
+    db_bind.execute(sa.sql.text('''
+        DROP INDEX IF EXISTS ix_definitions_term;
+    '''))
+    # re-create the standard index
+    db_bind.execute(sa.sql.text('''
+        CREATE INDEX ix_definitions_term ON definitions(term);
+    '''))
+
+    #
+    # Remove support for full-text search on terms and descriptions
+    #
+
+    # drop the tsv_search column from the definitions table
+    db_bind.execute(sa.sql.text('''
+        ALTER TABLE definitions DROP COLUMN IF EXISTS tsv_search;
+    '''))
+
+    # drop the search trigger and function
+    db_bind.execute(sa.sql.text('''
+        DROP TRIGGER IF EXISTS tsvupdate_definitions_trigger ON definitions;
+    '''))
+    db_bind.execute(sa.sql.text('''
+        DROP FUNCTION IF EXISTS definitions_search_trigger();
+    '''))
+
+    # drop the index
+    db_bind.execute(sa.sql.text('''
+        DROP INDEX IF EXISTS ix_definitions_tsv_search;
+    '''))

--- a/migrations/versions/201bae6698f6_added_search.py
+++ b/migrations/versions/201bae6698f6_added_search.py
@@ -1,4 +1,4 @@
-"""Added new column for ranked searching of terms and descriptions
+"""Added new column for ranked searching of terms and definitions
 
 Revision ID: 201bae6698f6
 Revises: 4614666a279f
@@ -29,7 +29,7 @@ def upgrade():
     '''))
 
     #
-    # Support full-text search on terms and descriptions
+    # Support full-text search on terms and definitions
     #
 
     # add the tsv_search column to the definitions table
@@ -46,7 +46,7 @@ def upgrade():
         begin
           new.tsv_search :=
              setweight(to_tsvector('pg_catalog.english', COALESCE(new.term,'')), 'A') ||
-             setweight(to_tsvector('pg_catalog.english', COALESCE(new.description,'')), 'B');
+             setweight(to_tsvector('pg_catalog.english', COALESCE(new.definition,'')), 'B');
           return new;
         end
         $$ LANGUAGE plpgsql;
@@ -69,7 +69,7 @@ def upgrade():
 
     # populate tsv_search for existing records
     db_bind.execute(sa.sql.text('''
-        UPDATE definitions SET tsv_search = setweight(to_tsvector('pg_catalog.english', COALESCE(term,'')), 'A') || setweight(to_tsvector('pg_catalog.english', COALESCE(description,'')), 'B');
+        UPDATE definitions SET tsv_search = setweight(to_tsvector('pg_catalog.english', COALESCE(term,'')), 'A') || setweight(to_tsvector('pg_catalog.english', COALESCE(definition,'')), 'B');
     '''))
 
 def downgrade():
@@ -88,7 +88,7 @@ def downgrade():
     '''))
 
     #
-    # Remove support for full-text search on terms and descriptions
+    # Remove support for full-text search on terms and definitions
     #
 
     # drop the tsv_search column from the definitions table

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+# -*- coding: utf8 -*-
+import unittest
+from os import environ
+from gloss import create_app, db
+
+class TestBase(unittest.TestCase):
+    ''' A base class for bot tests.
+    '''
+
+    def setUp(self):
+        environ['DATABASE_URL'] = 'postgres:///glossary-bot-test'
+        environ['SLACK_TOKEN'] = 'meowser_token'
+        environ['SLACK_WEBHOOK_URL'] = 'http://hooks.example.com/services/HELLO/LOVELY/WORLD'
+
+        self.app = create_app(environ)
+        self.app_context = self.app.app_context()
+        self.app_context.push()
+
+        self.db = db
+        self.client = self.app.test_client()
+
+    def tearDown(self):
+        self.db.session.close()
+        self.db.drop_all()
+        # drop_all doesn't drop the alembic_version table
+        self.db.session.execute('DROP TABLE IF EXISTS alembic_version')
+        self.db.session.commit()
+        self.app_context.pop()
+
+    def post_command(self, text, slash_command=u'/gloss'):
+        return self.client.post('/', data={'token': u'meowser_token', 'text': text, 'user_name': u'glossie', 'channel_id': u'123456', 'command': slash_command})

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -1,38 +1,19 @@
 #!/usr/bin/env python
 # -*- coding: utf8 -*-
 import unittest
+import json
 from httmock import response, HTTMock
-from os import environ
 from flask import current_app
-from gloss import create_app, db
 from gloss.models import Definition, Interaction
 from gloss.views import query_definition
 from datetime import datetime, timedelta
-import json
+from tests.test_base import TestBase
 
-class BotTestCase(unittest.TestCase):
+class TestBot(TestBase):
 
     def setUp(self):
-        environ['DATABASE_URL'] = 'postgres:///glossary-bot-test'
-        environ['SLACK_TOKEN'] = 'meowser_token'
-        environ['SLACK_WEBHOOK_URL'] = 'http://hooks.example.com/services/HELLO/LOVELY/WORLD'
-
-        self.app = create_app(environ)
-        self.app_context = self.app.app_context()
-        self.app_context.push()
-
-        self.db = db
+        super(TestBot, self).setUp()
         self.db.create_all()
-
-        self.client = self.app.test_client()
-
-    def tearDown(self):
-        self.db.session.close()
-        self.db.drop_all()
-        self.app_context.pop()
-
-    def post_command(self, text, slash_command=u'/gloss'):
-        return self.client.post('/', data={'token': u'meowser_token', 'text': text, 'user_name': u'glossie', 'channel_id': u'123456', 'command': slash_command})
 
     def test_app_exists(self):
         ''' The app exists

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -603,37 +603,6 @@ class TestBot(TestBase):
         self.assertEqual(robo_response.status_code, 200)
         self.assertTrue(u', '.join(check) in robo_response.data)
 
-    def test_today_and_yesterday_learnings(self):
-        ''' Today's learnings are returned when requested
-        '''
-        # set some values in the database
-        letters = [u'E', u'F', u'G', u'H', u'I', u'J', u'K', u'L', u'M', u'N', u'O', u'P', u'Q', u'R', u'S', u'T', u'U', u'V', u'W', u'X']
-        check = []
-        for letter in letters:
-            self.post_command(text=u'{letter}W = {letter}ligibility Worker'.format(letter=letter))
-            check.insert(0, u'{}W'.format(letter))
-
-        # change the date on some of the values
-        change_count = 11
-        time_travelers = check[:change_count]
-        check = check[change_count:]
-        date_yesterday = datetime.utcnow() - timedelta(days=1)
-        for term in time_travelers:
-            entry = query_definition(term)
-            entry.creation_date = date_yesterday
-            self.db.session.add(entry)
-            self.db.session.commit()
-
-        # get today's learnings
-        robo_response = self.post_command(text=u'shh learnings today')
-        self.assertEqual(robo_response.status_code, 200)
-        self.assertTrue(u', '.join(check) in robo_response.data)
-
-        # get yesterday's
-        robo_response = self.post_command(text=u'shh learnings yesterday')
-        self.assertEqual(robo_response.status_code, 200)
-        self.assertTrue(u', '.join(time_travelers) in robo_response.data)
-
     def test_learnings_language(self):
         ''' Language describing learnings is numerically accurate
         '''

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -640,8 +640,8 @@ class BotTestCase(unittest.TestCase):
         for term in time_travelers:
             entry = query_definition(term)
             entry.creation_date = date_yesterday
-            db.session.add(entry)
-            db.session.commit()
+            self.db.session.add(entry)
+            self.db.session.commit()
 
         # get today's learnings
         robo_response = self.post_command(text=u'shh learnings today')

--- a/tests/test_bot_search.py
+++ b/tests/test_bot_search.py
@@ -64,20 +64,20 @@ class TestBotSearch(TestBase):
 
         # make some searchs and verify that they come back as expected
         robo_response = self.post_command(text=u'search youth')
-        self.assertTrue('following terms: *ACYF*, *TAY*' in robo_response.data)
+        self.assertTrue('found *youth* in: *ACYF*, *TAY*' in robo_response.data)
 
         robo_response = self.post_command(text=u'search saws')
-        self.assertTrue('following terms: *SAWS*, *CalWIN*' in robo_response.data)
+        self.assertTrue('found *saws* in: *SAWS*, *CalWIN*' in robo_response.data)
 
         robo_response = self.post_command(text=u'search calwin')
-        self.assertTrue('following terms: *CalWIN*, *SAWS*')
+        self.assertTrue('found *calwin* in: *CalWIN*, *SAWS*')
 
         robo_response = self.post_command(text=u'search state')
         self.assertTrue('*TAY*' in robo_response.data)
         self.assertTrue('*WIB*' in robo_response.data)
 
         robo_response = self.post_command(text=u'search banana')
-        self.assertTrue('*banana* was not found in any terms or definitions.' in robo_response.data)
+        self.assertTrue('Gloss Bot could not find *banana* in any terms or definitions.' in robo_response.data)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_bot_search.py
+++ b/tests/test_bot_search.py
@@ -45,5 +45,39 @@ class TestBotSearch(TestBase):
         match_text = ', '.join(['*{}*'.format(item[0]) for item in matches])
         self.assertTrue(match_text in robo_response.data)
 
+    def test_search_results(self):
+        ''' A search of terms and definitions returns the expected results.
+        '''
+        # set some definitions
+        matches = [
+            (u'CalWIN', u'CalWORKs Information Network, a service supporting the administration of public assistance programs in a consortium of California counties, including CalFresh, Medi-Cal, General Assistance, and Foster Care. Part of SAWS.'),
+            (u'TAY', u'Transitional Age Youth, people between the ages of sixteen and twenty-four who are in transition from state custody or foster care and are at-risk.'),
+            (u'SAWS', u'the Statewide Automated Welfare System, made up of multiple systems (including C-IV, CalWin and LEADER) which support eligibility and benefit determination, enrollment, and case maintenance at the county level for some of California\'s major health and human services programs.'),
+            (u'WIB', u'Workforce Investment Board, a regional entity created to implement the Workforce Investment Act of 1998 by directing federal, state and local funding to workforce development programs.'),
+            (u'ACYF', u'Administration for Children, Youth and Families, a part of the Administration for Children and Families, under the Department of Health and Human Services, administered by a commissioner who is a presidential appointee. ACYF is divided into two bureaus: the Children\'s Bureau and the Family and Youth Services Bureau, each of which is responsible for different issues involving children, youth and families and with a cross-cutting unit responsible for research and evaluation.')
+        ]
+        # set the definitions in random order
+        randomized_matches = list(matches)
+        random.shuffle(randomized_matches)
+        for post_match in randomized_matches:
+            self.post_command(text=u'{} = {}'.format(post_match[0], post_match[1]))
+
+        # make some searchs and verify that they come back as expected
+        robo_response = self.post_command(text=u'search youth')
+        self.assertTrue('following terms: *ACYF*, *TAY*' in robo_response.data)
+
+        robo_response = self.post_command(text=u'search saws')
+        self.assertTrue('following terms: *SAWS*, *CalWIN*' in robo_response.data)
+
+        robo_response = self.post_command(text=u'search calwin')
+        self.assertTrue('following terms: *CalWIN*, *SAWS*')
+
+        robo_response = self.post_command(text=u'search state')
+        self.assertTrue('*TAY*' in robo_response.data)
+        self.assertTrue('*WIB*' in robo_response.data)
+
+        robo_response = self.post_command(text=u'search banana')
+        self.assertTrue('*banana* was not found in any terms or definitions.' in robo_response.data)
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_bot_search.py
+++ b/tests/test_bot_search.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python
+# -*- coding: utf8 -*-
+import unittest
+import logging
+import random
+from flask_migrate import upgrade
+from flask.ext.migrate import Migrate
+from tests.test_base import TestBase
+
+class TestBotSearch(TestBase):
+
+    def setUp(self):
+        super(TestBotSearch, self).setUp()
+        # suppress logging
+        logging.disable(logging.CRITICAL)
+        # run the database migrations
+        Migrate(self.app, self.db)
+        upgrade()
+
+    def tearDown(self):
+        super(TestBotSearch, self).tearDown()
+        logging.disable(logging.NOTSET)
+
+    def test_suggestions_made_when_no_match_found(self):
+        ''' When a definition is requested for a term that isn't in the database, a list
+            of suggestions is returned.
+        '''
+        # set some definitions
+        # this is the order the matches should be returned in
+        matches = [
+            (u'pastinkmy', u'a funky lunchmeat'),
+            (u'stinked stink', u'a really bad smell'),
+            (u'standard stink', u'a bad smell'),
+            (u'foul odor', u'a stink that is really stinking up the room'),
+            (u'stench', u'a prominent stink')
+        ]
+        # set the definitions in random order
+        randomized_matches = list(matches)
+        random.shuffle(randomized_matches)
+        for post_match in randomized_matches:
+            self.post_command(text=u'{} = {}'.format(post_match[0], post_match[1]))
+
+        # request a definition that doesn't exist, but that will generate suggestions
+        robo_response = self.post_command(text=u'shh stink')
+        match_text = ', '.join(['*{}*'.format(item[0]) for item in matches])
+        self.assertTrue(match_text in robo_response.data)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
If there's no exact match for a definition request, searches terms and definitions to generate suggested matches. Also adds a new `search` command. And gets rid of the `today` and `tomorrow` modifiers for the `learnings` command, because results were inconsistent.

It doesn't do a fuzzy search, but I'm still going to say it closes #11 